### PR TITLE
Fix test_client response parsing bug

### DIFF
--- a/test_client.py
+++ b/test_client.py
@@ -94,7 +94,7 @@ def call_with_payload(url, payload):
         resp.raise_for_status()
         data = resp.json()
         msgs = data.get("messages", [])
-        if not msgs or len(msgs) < 2:  # Need at least query and response
+        if not msgs:
             return "No valid response received"
         
         # Get the agent's response message (last message)


### PR DESCRIPTION
## Summary
- allow test_client to accept single-message responses

## Testing
- `python -m pytest -q` *(fails: ModuleNotFoundError: No module named 'requests')*

------
https://chatgpt.com/codex/tasks/task_e_683fd8d8bad88325a75ae7d44a3b58d6